### PR TITLE
chore: removed the "global" folder from published package manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
 	"homepage": "https://github.com/Vonage/vivid-design-tokens-properties",
 	"license": "ISC",
 	"files": [
-		"globals",
 		"typography",
 		"dist"
 	],


### PR DESCRIPTION
the "global" folder is not accessed by the package consumers anymore? 